### PR TITLE
Collect, don't clobber, results in BatchLookupResolver.initialize()

### DIFF
--- a/unbound_ec2.py
+++ b/unbound_ec2.py
@@ -170,7 +170,7 @@ class BatchLookupResolver(EC2NameResolver):
     """
     def __init__(self, ec2, zone):
         super(BatchLookupResolver, self).__init__(ec2, zone)
-        self.lookup_cache = {}
+        self.lookup_cache = defaultdict(list)
         self.initialize()
 
     def initialize(self):
@@ -184,7 +184,8 @@ class BatchLookupResolver(EC2NameResolver):
         self.lookup_cache.clear()
 
         for instance in itertools.chain(*(i.instances for i in reservations)):
-            self.lookup_cache.update(self._lookup(instance))
+            for name, addresses in self._lookup(instance).items():
+                self.lookup_cache[name].extend(addresses)
 
     def __call__(self, name):
         return self.lookup_cache[name.rstrip('.')]


### PR DESCRIPTION
Previously, `_lookup()` returned a dict like `{names:
[addresses]}`. `initialize()` iterated through matching results, calling
`update` on the `lookup_cache` dict for each match. Each update call would
clobber any existing data in a `name` key with a new set of
`addresses`. Practically, this meant that queries that should match several
instances and therefore return round-robin records (with all matching
addresses) instead returned plain A records (with the last matching address).

Here, we add another loop through the `_lookup()` result items and extend the
cache dict with all new addresses found. This restores the expected
round-robin behavior.
